### PR TITLE
feat: implement change password API

### DIFF
--- a/app/change-password/page.tsx
+++ b/app/change-password/page.tsx
@@ -5,7 +5,8 @@ import { useAuthGuard } from "@/lib/useAuthGuard";
 import clsx from "clsx";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
+import { changePassword } from "@/lib/api/auth";
 
 export default function ChangePasswordPage() {
   useAuthGuard();
@@ -19,6 +20,13 @@ export default function ChangePasswordPage() {
   const [error, setError] = useState("");
   const [showPasswordGuide, setShowPasswordGuide] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const mustChange = localStorage.getItem("mustChangePassword");
+    if (mustChange !== "true") {
+      router.replace("/agent-dashboard");
+    }
+  }, [router]);
 
   // -----------------------------
   // Password Validation Rules
@@ -65,8 +73,14 @@ export default function ChangePasswordPage() {
     }
 
     // TODO: Replace with actual password update API call
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    router.push("/dashboard");
+    try {
+      await changePassword(newPassword);
+      localStorage.setItem("mustChangePassword", "false");
+      router.push("/agent-dashboard");
+    } catch (err: any) {
+      setError(err.message || "Password change failed");
+      return;
+    }
   };
 
   // -----------------------------

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -23,6 +23,7 @@ export default function LoginPage() {
       const req: LoginRequest = { username, password };
       const res = await login(req);
       localStorage.setItem("token", res.token);
+      localStorage.setItem("mustChangePassword", JSON.stringify(res.mustChangePassword));
       if (res.mustChangePassword) {
         router.push("/change-password");
       } else {

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -14,14 +14,19 @@ export async function login({
       mustChangePassword: false,
     };
   }
-  if (!SERVER_URL) {
-    throw new Error(
-      "No backend server configured. Set NEXT_PUBLIC_SERVER_URL."
-    );
-  }
   const response = await axios.post(`${SERVER_URL}/api/sign-in`, {
     username,
     password,
   });
   return response.data;
+}
+
+export async function changePassword(newPassword: string): Promise<void> {
+  const token = localStorage.getItem("token");
+
+  await axios.post(
+    `${SERVER_URL}/api/change-password`,
+    { newPassword },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
 }


### PR DESCRIPTION
## Summary
- Integrates the backend API for changing user passwords.
- Restricts access to the /change-password page so that only users who are required to change their password (based on the mustChangePassword flag) can access it.
- Updates the login flow to store the mustChangePassword state in localStorage.
- After a successful password change, updates the state and redirects the user to the dashboard.